### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/safety-check.yml
+++ b/.github/workflows/safety-check.yml
@@ -1,4 +1,6 @@
 name: Safety & Accuracy Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/N0tHorizon/WindowsTelemetryBlocker/security/code-scanning/4](https://github.com/N0tHorizon/WindowsTelemetryBlocker/security/code-scanning/4)

To address the issue, add a top-level `permissions` block in `.github/workflows/safety-check.yml`, specifying only the permissions necessary for the workflow. Since none of the steps require any write access or GitHub API operations—only access to the repository contents to check scripts and documentation—all that is needed is `contents: read`. This setting should go at the root of the YAML file, just below the workflow name and before `on:` and `jobs:`. This adjustment strictly follows GitHub's security recommendation and CodeQL's suggestion.

Specifically:
- Add a block:
  ```yaml
  permissions:
    contents: read
  ```
- Place it after the `name` declaration, e.g., between lines 1 and 3.

No other code, imports, or step modifications are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
