### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/uci.yml
+++ b/.github/workflows/uci.yml
@@ -1,4 +1,6 @@
 name: Project Compliance Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/N0tHorizon/WindowsTelemetryBlocker/security/code-scanning/3](https://github.com/N0tHorizon/WindowsTelemetryBlocker/security/code-scanning/3)

To fix this issue, add an explicit `permissions` block to limit the `GITHUB_TOKEN` capabilities for the workflow. The minimal and recommended default is `contents: read`, which allows reads but denies writes to repository contents and other privileged actions. This `permissions` block can be added at the top "root" level of the workflow (affecting all jobs) or at the individual job level. Since this workflow's steps are informational and only need to read code and files, `contents: read` is sufficient. Insert the following directly after the `name:` line and before `on:` to define it globally for the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
