### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -42,7 +42,7 @@ jobs:
           args: >
             -Dsonar.sources=.
             -Dsonar.scanAll=true
-            -Dsonar.externalIssuesReportPaths=codescan.sarif
+            -Dsonar.report.export.path=codescan.sarif
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -42,6 +42,7 @@ jobs:
           args: >
             -Dsonar.sources=.
             -Dsonar.scanAll=true
+            -Dsonar.externalIssuesReportPaths=codescan.sarif
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Potential fix for [https://github.com/N0tHorizon/WindowsTelemetryBlocker/security/code-scanning/1](https://github.com/N0tHorizon/WindowsTelemetryBlocker/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the workflow, specifying that only read access to repository contents is allowed. This should be done at the root level (global to the workflow), so all jobs inherit the restriction by default. Edit the top of `.github/workflows/ci.yml` to insert a `permissions` block right after the `name:` declaration and before `on:`. The syntax should be:

```yaml
permissions:
  contents: read
```

No other changes or imports are needed. This does not change existing functionality and aligns with security recommendations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
