### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/env-matrix.yml
+++ b/.github/workflows/env-matrix.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["🌕Nextgen", "📦Current"]
 
+permissions:
+  contents: read
+
 jobs:
   matrix-test:
     name: "env: ${{ matrix.os }} | Shell: ${{ matrix.shell }} | Admin: ${{ matrix.admin }} | Locale: ${{ matrix.locale }}"


### PR DESCRIPTION
Potential fix for [https://github.com/N0tHorizon/WindowsTelemetryBlocker/security/code-scanning/7](https://github.com/N0tHorizon/WindowsTelemetryBlocker/security/code-scanning/7)

In general, you fix this issue by explicitly setting a `permissions` block in the workflow (at the root or per job) to restrict the `GITHUB_TOKEN` to only what is needed. For a workflow that merely checks the environment and uploads artifacts, no repository write permissions are required; read access to contents is sufficient, and in many cases the token can be fully disabled.

The best fix here, without changing behavior, is to add a root‑level `permissions` block just under the `on:` section, applying to all jobs. Because this workflow only reads the code (via `actions/checkout`) and uploads artifacts (which does not require GITHUB_TOKEN), `contents: read` is a safe, minimal choice that still allows checkout to function. No other scopes (like `pull-requests`, `issues`, etc.) are needed based on the shown steps. Concretely, in `.github/workflows/env-matrix.yml`, add:

```yaml
permissions:
  contents: read
```

between the `on:` block (line 3–7) and the `jobs:` block (line 9). No imports or additional methods are required since this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
